### PR TITLE
Bump version to v2.1.0, fix TypeToken backup import & timetable updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
     applicationId = "com.agupta07505.attendsmartly"
     minSdk = 24
     targetSdk = 36
-    versionCode = 2
-    versionName = "2.0"
+    versionCode = 3
+    versionName = "2.1.0"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -31,6 +31,8 @@
 # ==============================================================================
 -keep class com.agupta07505.attendsmartly.domain.model.** { *; }
 -keep class com.agupta07505.attendsmartly.util.AttendSmartlyBackup { *; }
+-keep class com.agupta07505.attendsmartly.util.TimetableSharePackage { *; }
+-keep class com.agupta07505.attendsmartly.util.ExportImportUtils { *; }
 -keepclassmembers class * implements java.io.Serializable {
     static final long serialVersionUID;
     private static final java.io.ObjectStreamField[] serialPersistentFields;

--- a/app/src/main/java/com/agupta07505/attendsmartly/util/ExportImportUtils.kt
+++ b/app/src/main/java/com/agupta07505/attendsmartly/util/ExportImportUtils.kt
@@ -14,7 +14,6 @@ import com.agupta07505.attendsmartly.data.repository.AttendSmartlyRepository
 import com.agupta07505.attendsmartly.domain.calculator.AttendanceCalculator
 import com.agupta07505.attendsmartly.domain.model.AttendanceStatus
 import com.google.gson.*
-import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.flow.first
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -276,22 +275,40 @@ object ExportImportUtils {
         }
     }
 
-    private inline fun <reified T> tryParseArray(arrayJson: String): List<T> {
-        val listType = object : TypeToken<List<T>>() {}.type
-        return try {
-            val parsed: List<T>? = gson.fromJson(arrayJson, listType)
-            parsed?.filterNotNull() ?: emptyList()
-        } catch (e: Exception) {
-            val results = mutableListOf<T>()
-            val objects = extractObjectsFromBlock(arrayJson)
-            for (objStr in objects) {
-                try {
-                    val obj = gson.fromJson(objStr, T::class.java)
-                    if (obj != null) results.add(obj)
-                } catch (_: Exception) {}
-            }
-            results
+    fun <T> parseJsonArray(jsonArray: JsonArray, clazz: Class<T>): List<T> {
+        val list = mutableListOf<T>()
+        for (elem in jsonArray) {
+            try {
+                val item = gson.fromJson(elem, clazz)
+                if (item != null) list.add(item)
+            } catch (_: Exception) {}
         }
+        return list
+    }
+
+    fun <T> tryParseArray(arrayJson: String, clazz: Class<T>): List<T> {
+        val list = mutableListOf<T>()
+        try {
+            val elem = JsonParser.parseString(arrayJson)
+            if (elem.isJsonArray) {
+                for (item in elem.asJsonArray) {
+                    try {
+                        val obj = gson.fromJson(item, clazz)
+                        if (obj != null) list.add(obj)
+                    } catch (_: Exception) {}
+                }
+                if (list.isNotEmpty()) return list
+            }
+        } catch (_: Exception) {}
+
+        val objects = extractObjectsFromBlock(arrayJson)
+        for (objStr in objects) {
+            try {
+                val obj = gson.fromJson(objStr, clazz)
+                if (obj != null) list.add(obj)
+            } catch (_: Exception) {}
+        }
+        return list
     }
 
     fun extractEntitiesFromMalformedJson(
@@ -318,11 +335,11 @@ object ExportImportUtils {
                 val arrayContent = extractBalancedSection(rawText, arrayStart, '[', ']')
                 if (arrayContent != null) {
                     when (type) {
-                        "subjects" -> outSubjects.addAll(tryParseArray<SubjectEntity>(arrayContent))
-                        "timetable" -> outTimetable.addAll(tryParseArray<TimetableEntryEntity>(arrayContent))
-                        "sessions" -> outSessions.addAll(tryParseArray<AttendanceSessionEntity>(arrayContent))
-                        "units" -> outUnits.addAll(tryParseArray<AttendanceUnitEntity>(arrayContent))
-                        "holidays" -> outHolidays.addAll(tryParseArray<HolidayEntity>(arrayContent))
+                        "subjects" -> outSubjects.addAll(tryParseArray(arrayContent, SubjectEntity::class.java))
+                        "timetable" -> outTimetable.addAll(tryParseArray(arrayContent, TimetableEntryEntity::class.java))
+                        "sessions" -> outSessions.addAll(tryParseArray(arrayContent, AttendanceSessionEntity::class.java))
+                        "units" -> outUnits.addAll(tryParseArray(arrayContent, AttendanceUnitEntity::class.java))
+                        "holidays" -> outHolidays.addAll(tryParseArray(arrayContent, HolidayEntity::class.java))
                     }
                 }
             }
@@ -419,62 +436,44 @@ object ExportImportUtils {
                     // Parse subjects
                     val subjectsJson = findArray("subjects", "subjectList", "subject_list", "allSubjects", "subjectsList")
                     if (subjectsJson != null) {
-                        val listType = object : TypeToken<List<SubjectEntity>>() {}.type
-                        val parsedSubjects: List<SubjectEntity>? = gson.fromJson(subjectsJson, listType)
-                        parsedSubjects?.let { subjects.addAll(it) }
+                        subjects.addAll(parseJsonArray(subjectsJson, SubjectEntity::class.java))
                     }
 
                     // Parse timetable entries
                     val timetableJson = findArray("timetableEntries", "timetable_entries", "timetable", "entries", "allTimetableEntries", "schedule", "timetableList")
                     if (timetableJson != null) {
-                        val listType = object : TypeToken<List<TimetableEntryEntity>>() {}.type
-                        val parsedEntries: List<TimetableEntryEntity>? = gson.fromJson(timetableJson, listType)
-                        parsedEntries?.let { timetableEntries.addAll(it) }
+                        timetableEntries.addAll(parseJsonArray(timetableJson, TimetableEntryEntity::class.java))
                     }
 
                     // Parse sessions
                     val sessionsJson = findArray("sessions", "attendanceSessions", "attendance_sessions", "attendance", "allSessions", "sessionList", "session_list")
                     if (sessionsJson != null) {
-                        val listType = object : TypeToken<List<AttendanceSessionEntity>>() {}.type
-                        val parsedSessions: List<AttendanceSessionEntity>? = gson.fromJson(sessionsJson, listType)
-                        parsedSessions?.let { sessions.addAll(it) }
+                        sessions.addAll(parseJsonArray(sessionsJson, AttendanceSessionEntity::class.java))
                     }
 
                     // Parse units
                     val unitsJson = findArray("units", "attendanceUnits", "attendance_units", "allUnits", "unitList", "unit_list")
                     if (unitsJson != null) {
-                        val listType = object : TypeToken<List<AttendanceUnitEntity>>() {}.type
-                        val parsedUnits: List<AttendanceUnitEntity>? = gson.fromJson(unitsJson, listType)
-                        parsedUnits?.let { units.addAll(it) }
+                        units.addAll(parseJsonArray(unitsJson, AttendanceUnitEntity::class.java))
                     }
 
                     // Parse holidays
                     val holidaysJson = findArray("holidays", "holidayList", "holiday_list", "allHolidays")
                     if (holidaysJson != null) {
-                        val listType = object : TypeToken<List<HolidayEntity>>() {}.type
-                        val parsedHolidays: List<HolidayEntity>? = gson.fromJson(holidaysJson, listType)
-                        parsedHolidays?.let { holidays.addAll(it) }
+                        holidays.addAll(parseJsonArray(holidaysJson, HolidayEntity::class.java))
                     }
                 } else if (jsonElement.isJsonArray) {
                     val array = jsonElement.asJsonArray
                     if (array.size() > 0 && array.get(0).isJsonObject) {
                         val firstObj = array.get(0).asJsonObject
                         if (firstObj.has("dayOfWeek") || (firstObj.has("startTime") && !firstObj.has("sessionDate"))) {
-                            val listType = object : TypeToken<List<TimetableEntryEntity>>() {}.type
-                            val parsedEntries: List<TimetableEntryEntity>? = gson.fromJson(array, listType)
-                            parsedEntries?.let { timetableEntries.addAll(it) }
+                            timetableEntries.addAll(parseJsonArray(array, TimetableEntryEntity::class.java))
                         } else if (firstObj.has("sessionDate")) {
-                            val listType = object : TypeToken<List<AttendanceSessionEntity>>() {}.type
-                            val parsedSessions: List<AttendanceSessionEntity>? = gson.fromJson(array, listType)
-                            parsedSessions?.let { sessions.addAll(it) }
+                            sessions.addAll(parseJsonArray(array, AttendanceSessionEntity::class.java))
                         } else if (firstObj.has("targetPercentage") || firstObj.has("colorValue") || firstObj.has("teacherName")) {
-                            val listType = object : TypeToken<List<SubjectEntity>>() {}.type
-                            val parsedSubjects: List<SubjectEntity>? = gson.fromJson(array, listType)
-                            parsedSubjects?.let { subjects.addAll(it) }
+                            subjects.addAll(parseJsonArray(array, SubjectEntity::class.java))
                         } else {
-                            val listType = object : TypeToken<List<TimetableEntryEntity>>() {}.type
-                            val parsedEntries: List<TimetableEntryEntity>? = gson.fromJson(array, listType)
-                            parsedEntries?.let { timetableEntries.addAll(it) }
+                            timetableEntries.addAll(parseJsonArray(array, TimetableEntryEntity::class.java))
                         }
                     }
                 }

--- a/app/src/test/java/com/agupta07505/attendsmartly/ExportImportUtilsTest.kt
+++ b/app/src/test/java/com/agupta07505/attendsmartly/ExportImportUtilsTest.kt
@@ -199,9 +199,8 @@ class ExportImportUtilsTest {
         assertTrue(jsonElement.isJsonObject)
         val obj = jsonElement.asJsonObject
 
-        val subjectsJson = obj.get("subjects")
-        val listType = object : com.google.gson.reflect.TypeToken<List<SubjectEntity>>() {}.type
-        val parsedSubjects: List<SubjectEntity> = Gson().fromJson(subjectsJson, listType)
+        val subjectsJson = obj.get("subjects").asJsonArray
+        val parsedSubjects = ExportImportUtils.parseJsonArray(subjectsJson, SubjectEntity::class.java)
 
         assertEquals(1, parsedSubjects.size)
         val sanitizedSub = ExportImportUtils.sanitizeSubject(parsedSubjects[0])
@@ -211,34 +210,30 @@ class ExportImportUtilsTest {
         assertEquals("Book", sanitizedSub.iconName)
         assertEquals(60, sanitizedSub.defaultSessionDurationMinutes)
 
-        val timetableJson = obj.get("timetableEntries")
-        val entryType = object : com.google.gson.reflect.TypeToken<List<TimetableEntryEntity>>() {}.type
-        val parsedEntries: List<TimetableEntryEntity> = Gson().fromJson(timetableJson, entryType)
+        val timetableJson = obj.get("timetableEntries").asJsonArray
+        val parsedEntries = ExportImportUtils.parseJsonArray(timetableJson, TimetableEntryEntity::class.java)
         assertEquals(1, parsedEntries.size)
         val sanitizedEntry = ExportImportUtils.sanitizeTimetableEntry(parsedEntries[0])
         assertTrue(sanitizedEntry.isActive)
         assertEquals("09:00", sanitizedEntry.startTime)
         assertEquals("10:00", sanitizedEntry.endTime)
 
-        val sessionsJson = obj.get("sessions")
-        val sessType = object : com.google.gson.reflect.TypeToken<List<AttendanceSessionEntity>>() {}.type
-        val parsedSessions: List<AttendanceSessionEntity> = Gson().fromJson(sessionsJson, sessType)
+        val sessionsJson = obj.get("sessions").asJsonArray
+        val parsedSessions = ExportImportUtils.parseJsonArray(sessionsJson, AttendanceSessionEntity::class.java)
         assertEquals(1, parsedSessions.size)
         val sanitizedSession = ExportImportUtils.sanitizeSession(parsedSessions[0])
         assertEquals("2026-08-18", sanitizedSession.sessionDate)
         assertEquals(false, sanitizedSession.isRescheduled)
         assertEquals("", sanitizedSession.rescheduledReason)
 
-        val unitsJson = obj.get("units")
-        val unitType = object : com.google.gson.reflect.TypeToken<List<AttendanceUnitEntity>>() {}.type
-        val parsedUnits: List<AttendanceUnitEntity> = Gson().fromJson(unitsJson, unitType)
+        val unitsJson = obj.get("units").asJsonArray
+        val parsedUnits = ExportImportUtils.parseJsonArray(unitsJson, AttendanceUnitEntity::class.java)
         assertEquals(1, parsedUnits.size)
         val sanitizedUnit = ExportImportUtils.sanitizeUnit(parsedUnits[0], 201)
         assertEquals("PRESENT", sanitizedUnit.status)
 
-        val holidaysJson = obj.get("holidays")
-        val holType = object : com.google.gson.reflect.TypeToken<List<com.agupta07505.attendsmartly.data.local.entity.HolidayEntity>>() {}.type
-        val parsedHolidays: List<com.agupta07505.attendsmartly.data.local.entity.HolidayEntity> = Gson().fromJson(holidaysJson, holType)
+        val holidaysJson = obj.get("holidays").asJsonArray
+        val parsedHolidays = ExportImportUtils.parseJsonArray(holidaysJson, com.agupta07505.attendsmartly.data.local.entity.HolidayEntity::class.java)
         assertEquals(1, parsedHolidays.size)
         val sanitizedHoliday = ExportImportUtils.sanitizeHoliday(parsedHolidays[0])
         assertEquals("Independence Day", sanitizedHoliday.title)


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->

## Related Issue

<!-- Use "Closes #123" or "Fixes #123" when applicable. -->

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Build/CI release change

## App Area

- [ ] Timetable Scheduler & Unit Rules
- [ ] Safe Bunk & Recovery Calculator
- [ ] Attendance History & Session Logs
- [ ] Smart Timetable OCR Scanner
- [ ] Class Reminders (AlarmManager / WorkManager)
- [ ] Data Export / JSON Backups
- [ ] Jetpack Compose UI & Material 3 Theming
- [ ] Room Database & DataStore Preferences
- [ ] CI/CD or Gradle Configuration
- [ ] Documentation

## Screenshots Or Recordings

<!-- Required for visible UI changes. Add before/after screenshots when possible. -->

| Before | After |
|--------|-------|
|        |       |

## Testing

<!-- List commands, devices, emulators, and manual checks performed. -->

- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew assembleDebug`
- [ ] Manual device/emulator testing
- [ ] Unit calculation verification (Safe Bunk / Recovery)
- [ ] WorkManager / Alarm notification tested, if affected

## Checklist

- [ ] My code follows the existing project style and architecture.
- [ ] I kept the GPL v3 copyright header notice intact in all modified `.kt` files:
  ```kotlin
  /*
   * AttendSmartly (2026)
   * © Animesh Gupta — github.com/agupta07505
   * Licensed under the GNU GPL v3 License
   * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
   */
  ```
- [ ] I added or updated unit tests where useful.
- [ ] I updated docs when behavior or features changed.
- [ ] I did not commit secrets, API keys, keystores, or generated APKs.
